### PR TITLE
S Array Lookup in PRGA Implementation

### DIFF
--- a/rc4_demo.c
+++ b/rc4_demo.c
@@ -46,7 +46,7 @@ void rc4(unsigned char  *key,int key_len,char *buff,int len){
 		t1 = (t1 + 1)%256;
 		t2 = (t2 + s[t1])%256;
 		swap(&s[t1],&s[t2]);
-		val = (s[t1] + s[t2])%256;
+		val = s[(s[t1] + s[t2])%256];
 		out = *buff ^ val;
 		*buff=out;
 		buff++;


### PR DESCRIPTION
On line 49 the value currently saved as val should instead be used as an index into S before being used: https://en.wikipedia.org/wiki/RC4#Pseudo-random_generation_algorithm_(PRGA).

This fixes the output and aligns it with other online RC4 implementations.